### PR TITLE
Remove non needed imported resource

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -26,7 +26,6 @@ import {
 } from '@backstage/core-components';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
-import { QuarkusIcon } from "@internal/plugin-quarkus-console";
 
 const useSidebarLogoStyles = makeStyles({
   root: {


### PR DESCRIPTION
-  Remove non needed imported resource as we don't display the Quarkus icon