### PR TITLE
Fix a typo error and warn the user about how to grab the token generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Deploy the q-shift backstage application:
 cat manifest/templates/argocd.tmpl | NAMESPACE=<MY_NAMESPACE> envsubst > argocd.yaml
 kubectl apply -f argocd.yaml
 ```
+As the Secret's token needed by the backstage kubernetes plugin will be generated post backstage deployment, then you will have to grab the token to update
+your secret and next to rollout the backstage Deployment resource.
 
 **NOTE**: This project builds (with the help of a GitHub workflow) the backstage container image for openshift and pushes it on `quay.io/ch007m/backstage-qshift-ocp`
 

--- a/manifest/templates/backstage_env_secret.tmpl
+++ b/manifest/templates/backstage_env_secret.tmpl
@@ -11,4 +11,4 @@ ARGOCD_ADMIN_USER=admin
 ARGOCD_ADMIN_PASSWORD=<kubectl -n openshift-gitops get secret/openshift-gitops-cluster -ojson | jq '.data."admin.password" | @base64d'>
 
 KUBERNETES_API_URL=https://kubernetes.default.svc
-SERVICE_ACCOUNT_TOKEN=<kubectl -n MY_NAMESPACE get secret backstage-token-secret -o go-template='{{.data.token \| base64decode}}'>
+SERVICE_ACCOUNT_TOKEN=<kubectl -n MY_NAMESPACE get secret backstage-token-secret -o go-template='{{.data.token | base64decode}}'>


### PR DESCRIPTION
- Fix a typo error within the backstage secret env file template
- Warn the user within the README about how to grab the token generated post backstage installation