### PR TITLE
Play with quarkusVersionListField

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -34,8 +34,14 @@ import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
-import { QuarkusExtensionListField, QuarkusQuickstartPickerField } from '@qshift/plugin-quarkus';
+import {
+    QuarkusExtensionListField,
+    QuarkusQuickstartPickerField
+} from '@qshift/plugin-quarkus';
 import {QuarkusConsolePage} from "@qshift/plugin-quarkus-console";
+import {
+    QuarkusVersionListField,
+} from "./scaffolder/QuarkusVersionList";
 
 const app = createApp({
   apis,
@@ -81,6 +87,7 @@ const routes = (
         <ScaffolderFieldExtensions>
             <QuarkusQuickstartPickerField />
             <QuarkusExtensionListField />
+            <QuarkusVersionListField />
         </ScaffolderFieldExtensions>
     </Route>
     <Route path="/api-docs" element={<ApiExplorerPage />} />

--- a/packages/app/src/scaffolder/QuarkusVersionList/QuarkusVersionList.tsx
+++ b/packages/app/src/scaffolder/QuarkusVersionList/QuarkusVersionList.tsx
@@ -23,31 +23,33 @@ import {FieldExtensionComponentProps} from "@backstage/plugin-scaffolder-react";
   }
  */
 export interface Version {
-  key: string;
-  quarkusCoreVersion: string;
-  platformVersion: string;
-  lts: boolean;
-  recommended: boolean;
-  javaCompatibility: javaCompatibility[];
-  status: string;
+    key: string;
+    quarkusCoreVersion: string;
+    platformVersion: string;
+    lts: boolean;
+    recommended: boolean;
+    javaCompatibility: javaCompatibility[];
+    status: string;
 }
 
 export interface javaCompatibility {
-  recommended: boolean;
-  versions: string[];
+    recommended: boolean;
+    versions: string[];
 }
 
 function userLabel(v: Version) {
-  const key = v.key.split(":")
-  if (v.recommended) {
-    return `${key[1]} (RECOMMENDED)`;
-  } else if (v.status !== "FINAL") {
-    return `${key[1]} (${v.status})`;
-  } else {
-    return key[1];
-  }
+    const key = v.key.split(":")
+    if (v.recommended) {
+        return `${key[1]} (RECOMMENDED)`;
+    } else if (v.status !== "FINAL") {
+        return `${key[1]} (${v.status})`;
+    } else {
+        return key[1];
+    }
 }
 
+// TODO: Review the logic of this code against this backstage similar example to see if we can improve it:
+// https://github.com/backstage/backstage/blob/master/plugins/scaffolder/src/components/fields/EntityTagsPicker/EntityTagsPicker.tsx
 export const QuarkusVersionList = (props: FieldExtensionComponentProps<string>) => {
     const {
         onChange,
@@ -61,32 +63,36 @@ export const QuarkusVersionList = (props: FieldExtensionComponentProps<string>) 
     const [quarkusVersion, setQuarkusVersion] = useState<Version[]>([]);
     const [defaultQuarkusVersion, setDefaultQuarkusVersion] = useState<Version>();
 
-  const codeQuarkusUrl = 'https://code.quarkus.io';
-  const apiStreamsUrl = `${codeQuarkusUrl}/api/streams`
+    const codeQuarkusUrl = 'https://code.quarkus.io';
+    const apiStreamsUrl = `${codeQuarkusUrl}/api/streams`
 
-  const fetchData = async () => {
-    const response = await fetch(apiStreamsUrl);
-    const newData = await response.json();
-    setQuarkusVersion(newData)
-  }
+    const fetchData = async () => {
+        const response = await fetch(apiStreamsUrl);
+        const newData = await response.json();
+        setQuarkusVersion(newData)
+    }
 
-  useEffect(() => {
-    fetchData()
-  }, []);
+    useEffect(() => {
+        fetchData()
+    }, []);
 
-  useEffect(() => {
-    quarkusVersion.forEach(v => {
-      if (v.recommended) {
-        setDefaultQuarkusVersion({...v})
-      }
-    });
-  }, [quarkusVersion]);
+    useEffect(() => {
+        quarkusVersion.forEach(v => {
+            if (v.recommended) {
+                setDefaultQuarkusVersion({...v})
+                // @ts-ignore: TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
+                onChange([v.key]);
+            }
+        });
+    }, [quarkusVersion]);
 
-/*    function onSelectVersion(_,v) {
-        console.log(`Version selected: ${v.key}`)
-        // ! :-) version displayed within the review screen
-        onChange([v.key]);
-    }*/
+    function onSelectVersion(_: React.ChangeEvent<{}>, v: Version | null) {
+        console.log(`Version selected: ${v && v.key}`)
+        if (v) {
+            // @ts-ignore: TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
+            onChange([v.key]);
+        }
+    }
 
     if (defaultQuarkusVersion) {
         return (
@@ -101,13 +107,7 @@ export const QuarkusVersionList = (props: FieldExtensionComponentProps<string>) 
                     getOptionSelected={(option, value) => option.key === value.key}
                     getOptionLabel={(quarkusVersion) => userLabel(quarkusVersion)}
                     defaultValue={defaultQuarkusVersion}
-                    // onChange={onSelectVersion}
-                    onChange={(_,v) => {
-                        console.log(`Version selected: ${v.key}`)
-                        if (v) {
-                            onChange([v.key]);
-                        }
-                    }}
+                    onChange={onSelectVersion}
                     renderInput={(params) => (
                         <TextField
                             {...params}
@@ -115,14 +115,13 @@ export const QuarkusVersionList = (props: FieldExtensionComponentProps<string>) 
                             label="Select a quarkus version (QuarkusVersionList)"
                             required={required}
                             placeholder={placeholder}
-                            value={formData ?? ''}
                         />
                     )}
                 />
             </FormControl>)
     }
 
-  return (<div>Waiting to get the default Quarkus version ...</div>)
+    return (<div>Waiting to get the default Quarkus version ...</div>)
 }
 
 export default QuarkusVersionList;

--- a/packages/app/src/scaffolder/QuarkusVersionList/QuarkusVersionList.tsx
+++ b/packages/app/src/scaffolder/QuarkusVersionList/QuarkusVersionList.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import {useEffect, useState} from "react";
+import {Autocomplete} from "@material-ui/lab";
+import {TextField} from "@material-ui/core";
+import FormControl from "@material-ui/core/FormControl";
+import {FieldExtensionComponentProps} from "@backstage/plugin-scaffolder-react";
+
+/* Example returned by code.quarkus.io/api/streams
+{
+    "javaCompatibility": {
+      "recommended": 17,
+      "versions": [
+        17,
+        21
+      ]
+    },
+    "key": "io.quarkus.platform:3.8",
+    "lts": false,
+    "platformVersion": "3.8.2",
+    "quarkusCoreVersion": "3.8.2",
+    "recommended": true,
+    "status": "FINAL"
+  }
+ */
+export interface Version {
+  key: string;
+  quarkusCoreVersion: string;
+  platformVersion: string;
+  lts: boolean;
+  recommended: boolean;
+  javaCompatibility: javaCompatibility[];
+  status: string;
+}
+
+export interface javaCompatibility {
+  recommended: boolean;
+  versions: string[];
+}
+
+function userLabel(v: Version) {
+  const key = v.key.split(":")
+  if (v.recommended) {
+    return `${key[1]} (RECOMMENDED)`;
+  } else if (v.status !== "FINAL") {
+    return `${key[1]} (${v.status})`;
+  } else {
+    return key[1];
+  }
+}
+
+export const QuarkusVersionList = (props: FieldExtensionComponentProps<string>) => {
+    const {
+        onChange,
+        rawErrors,
+        required,
+        formData,
+        idSchema,
+        placeholder,
+    } = props;
+
+    const [quarkusVersion, setQuarkusVersion] = useState<Version[]>([]);
+    const [defaultQuarkusVersion, setDefaultQuarkusVersion] = useState<Version>();
+
+  const codeQuarkusUrl = 'https://code.quarkus.io';
+  const apiStreamsUrl = `${codeQuarkusUrl}/api/streams`
+
+  const fetchData = async () => {
+    const response = await fetch(apiStreamsUrl);
+    const newData = await response.json();
+    setQuarkusVersion(newData)
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, []);
+
+  useEffect(() => {
+    quarkusVersion.forEach(v => {
+      if (v.recommended) {
+        setDefaultQuarkusVersion({...v})
+      }
+    });
+  }, [quarkusVersion]);
+
+/*    function onSelectVersion(_,v) {
+        console.log(`Version selected: ${v.key}`)
+        // ! :-) version displayed within the review screen
+        onChange([v.key]);
+    }*/
+
+    if (defaultQuarkusVersion) {
+        return (
+            <FormControl
+                margin="normal"
+                required={required}
+                error={rawErrors?.length > 0 && !formData}
+            >
+                <Autocomplete
+                    id="quarkus-versions"
+                    options={quarkusVersion}
+                    getOptionSelected={(option, value) => option.key === value.key}
+                    getOptionLabel={(quarkusVersion) => userLabel(quarkusVersion)}
+                    defaultValue={defaultQuarkusVersion}
+                    // onChange={onSelectVersion}
+                    onChange={(_,v) => {
+                        console.log(`Version selected: ${v.key}`)
+                        if (v) {
+                            onChange([v.key]);
+                        }
+                    }}
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            id={idSchema?.$id}
+                            label="Select a quarkus version (QuarkusVersionList)"
+                            required={required}
+                            placeholder={placeholder}
+                            value={formData ?? ''}
+                        />
+                    )}
+                />
+            </FormControl>)
+    }
+
+  return (<div>Waiting to get the default Quarkus version ...</div>)
+}
+
+export default QuarkusVersionList;

--- a/packages/app/src/scaffolder/QuarkusVersionList/README.md
+++ b/packages/app/src/scaffolder/QuarkusVersionList/README.md
@@ -16,33 +16,39 @@ spec:
 
   parameters:
     - title: Provide information for the Quarkus Application
-      required:
-        - component_id
-        - owner
       properties:
-        component_id:
-          title: Name
-          type: string
-          description: Unique name of the application
-          default: my-quarkus-app
-          ui:field: EntityNamePicker
-
         QuarkusVersionList:
           title: Quarkus version
           type: array
           description: The list of the quarkus version
           ui:field: QuarkusVersionList
+
+  steps:
+  - id: register
+    name: Registering the Catalog Info Component
+    action: catalog:register
+    input:
+      repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+      catalogInfoPath: /catalog-info.yaml
 ```
-- Add it to your app-config.local.yaml file
+- Update your `all.yaml` file
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: quarkus-demo
+  description: "A collection of the Backstage resources: org, user, templates for the Quarkus demo"
+spec:
+  targets:
+    - ./org.yaml
+    - ./entities.yaml
+    - ./dummy/template.yaml
+```
+- Add it to your `app-config.local.yaml` file
 ```yaml
   locations:
-    # Quarkus template, org, entity
     - type: file
-      target: ../../temp/templates//org.yaml
-    - type: file
-      target: ../../temp/templates//entities.yaml
-    - type: file
-      target: ../../temp/templates/dummy/template.yaml
+      target: ../../temp/templates/all.yaml
       rules:
         - allow: [Template,Location,Component,System,Resource,User,Group]
 ```

--- a/packages/app/src/scaffolder/QuarkusVersionList/README.md
+++ b/packages/app/src/scaffolder/QuarkusVersionList/README.md
@@ -1,0 +1,56 @@
+## To play with the new field
+
+- Create a new template 
+```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: dummy
+  title: Dummy template for testing purpose
+  description: Dummy template for testing purpose
+  tags:
+    - dummy
+spec:
+  owner: guests
+  type: service
+
+  parameters:
+    - title: Provide information for the Quarkus Application
+      required:
+        - component_id
+        - owner
+      properties:
+        component_id:
+          title: Name
+          type: string
+          description: Unique name of the application
+          default: my-quarkus-app
+          ui:field: EntityNamePicker
+
+        QuarkusVersionList:
+          title: Quarkus version
+          type: array
+          description: The list of the quarkus version
+          ui:field: QuarkusVersionList
+```
+- Add it to your app-config.local.yaml file
+```yaml
+  locations:
+    # Quarkus template, org, entity
+    - type: file
+      target: ../../temp/templates//org.yaml
+    - type: file
+      target: ../../temp/templates//entities.yaml
+    - type: file
+      target: ../../temp/templates/dummy/template.yaml
+      rules:
+        - allow: [Template,Location,Component,System,Resource,User,Group]
+```
+- Launch the front and the backend in separate terminal
+```bash
+// terminal 1
+yarn start
+
+// terminal 1
+yarn start-backend
+```

--- a/packages/app/src/scaffolder/QuarkusVersionList/extensions.ts
+++ b/packages/app/src/scaffolder/QuarkusVersionList/extensions.ts
@@ -1,0 +1,10 @@
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import QuarkusVersionList from "./QuarkusVersionList"; // Version[] as within plugin project
+
+export const QuarkusVersionListField = scaffolderPlugin.provide(
+    createScaffolderFieldExtension({
+        name: 'QuarkusVersionList',
+        component: QuarkusVersionList,
+    }),
+);

--- a/packages/app/src/scaffolder/QuarkusVersionList/index.ts
+++ b/packages/app/src/scaffolder/QuarkusVersionList/index.ts
@@ -1,0 +1,3 @@
+export {
+    QuarkusVersionListField,
+} from './extensions';


### PR DESCRIPTION
## PR content

- Play with `quarkusVersionListField` using our backstage playGround app
- See: ./packages/app/src/scaffolder/QuarkusVersionList/README.md for instructions

## Issues

### Issue 1 : No quarkus version displayed when onchange not called
 
The code pushed here is working (=> quarkus version appears within the `review` screen) at the condition that user select a value from the popuplist.

![Screenshot 2024-03-20 at 14 16 37](https://github.com/q-shift/backstage-playground/assets/463790/2cc5cb56-84b4-4af9-930a-fbcd9a57e109)

Without selecting a value, you will get nothing

![Screenshot 2024-03-20 at 14 16 18](https://github.com/q-shift/backstage-playground/assets/463790/b5d9e019-3952-4396-89f1-186a1e82875b)

### Issue 2 : tsc fails

tsc fails 
```
yarn tsc
yarn run v1.22.21
$ tsc
packages/app/src/scaffolder/QuarkusVersionList/QuarkusVersionList.tsx:106:58 - error TS18047: 'v' is possibly 'null'.

106                         console.log(`Version selected: ${v.key}`)

packages/app/src/scaffolder/QuarkusVersionList/QuarkusVersionList.tsx:108:38 - error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.

108                             onChange([v.key]);
                                         ~~~~~~~
Found 2 errors in the same file, starting at: packages/app/src/scaffolder/QuarkusVersionList/QuarkusVersionList.tsx:106
```



