### PR TITLE
Add guest provider to the config.yaml file

### DIFF
--- a/manifest/helm/configmap/app-config.qshift.yaml
+++ b/manifest/helm/configmap/app-config.qshift.yaml
@@ -31,6 +31,7 @@ backend:
     - secret: ${BACKSTAGE_AUTH_SECRET} # Generate it using: node -p 'require("crypto").randomBytes(24).toString("base64")'
 
 auth:
+  environment: development
   # see https://backstage.io/docs/auth/ to learn about auth providers
   providers:
     guest: {}

--- a/manifest/helm/configmap/app-config.qshift.yaml
+++ b/manifest/helm/configmap/app-config.qshift.yaml
@@ -32,7 +32,8 @@ backend:
 
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
-  providers: {}
+  providers:
+    guest: {}
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/manifest/helm/configmap/app-config.qshift.yaml
+++ b/manifest/helm/configmap/app-config.qshift.yaml
@@ -34,7 +34,9 @@ auth:
   environment: development
   # see https://backstage.io/docs/auth/ to learn about auth providers
   providers:
-    guest: {}
+    guest: {
+      dangerouslyAllowOutsideDevelopment: true
+    }
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/manifest/templates/app-config.qshift.tmpl
+++ b/manifest/templates/app-config.qshift.tmpl
@@ -32,7 +32,8 @@ backend:
 
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
-  providers: {}
+  providers:
+    guest: {}
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/manifest/templates/app-config.qshift.tmpl
+++ b/manifest/templates/app-config.qshift.tmpl
@@ -34,7 +34,9 @@ auth:
   environment: development
   # see https://backstage.io/docs/auth/ to learn about auth providers
   providers:
-    guest: {}
+    guest: {
+      dangerouslyAllowOutsideDevelopment: true
+    }
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/manifest/templates/app-config.qshift.tmpl
+++ b/manifest/templates/app-config.qshift.tmpl
@@ -31,6 +31,7 @@ backend:
     keys: ${BACKSTAGE_AUTH_SECRET} # Generate it using: node -p 'require("crypto").randomBytes(24).toString("base64")'
 
 auth:
+  environment: development
   # see https://backstage.io/docs/auth/ to learn about auth providers
   providers:
     guest: {}


### PR DESCRIPTION
- Add guest provider to the config.yaml file
  ```
  auth:
  environment: development
  providers:
    guest: {
      dangerouslyAllowOutsideDevelopment: true
    }
  ```
- Update template used by argocd or locally