### PR TITLE
Use docker mount cache to share the yarn dependencies

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -35,7 +35,7 @@ RUN pip3 install mkdocs-techdocs-core==1.1.7
 # If this occurs, then ensure BuildKit is enabled (`DOCKER_BUILDKIT=1`) so the app dir is correctly created as `node`.
 WORKDIR /app
 RUN chown node:node /app
-# RUN chown node:node -R /home/node/.yarn/berry && chmod 644 -R /home/node/.yarn/berry
+
 USER node
 
 # This switches many Node.js dependencies to production mode.
@@ -51,8 +51,9 @@ COPY --chown=node:node .yarnrc.yml ./
 COPY --chown=node:node yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
 RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
-# TODO: Check how to fix the permissions here and if we need such a mount: --mount=type=cache,target=/home/node/.yarn/berry/cache,sharing=locked,uid=1000,gid=1000 \
-RUN yarn workspaces focus -A --production
+RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,sharing=locked,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/node/.yarn/berry/index,sharing=locked,uid=1000,gid=1000 \
+    yarn workspaces focus -A --production
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./

--- a/packages/backend/Dockerfile-ocp
+++ b/packages/backend/Dockerfile-ocp
@@ -43,7 +43,9 @@ COPY --chown=1001:0 .yarnrc.yml ./
 COPY --chown=1001:0 yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
 RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
-RUN yarn workspaces focus -A --production
+RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,sharing=locked,uid=1001,gid=0 \
+    --mount=type=cache,target=/home/node/.yarn/berry/index,sharing=locked,uid=1001,gid=0 \
+    yarn workspaces focus -A --production
 
 COPY --chown=1001:0 packages/backend/dist/bundle.tar.gz app-config*.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz


### PR DESCRIPTION
## Description

- Use docker mount cache to share the yarn dependencies = zip files of the packages between rebuild
- See: #121

## 2nd build of the image
```
yarn build-ocp-image -t quay.io/ch007m/backstage-qshift-ocp:latest 
[+] Building 0.7s (23/23) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile-ocp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 2.31kB                                                                                                                                                                                         0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/nodejs-18:latest                                                                                                                                              0.5s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 191B                                                                                                                                                                                              0.0s
 => [stage-0  1/17] FROM registry.access.redhat.com/ubi9/nodejs-18:latest@sha256:b7e74833e4ea1592a1f414852fc0138cdeca91aecdcd79bc4f2c68cd1b6cbd0e                                                                              0.0s
 => [internal] load build context                                                                                                                                                                                              0.1s
 => => transferring context: 905B                                                                                                                                                                                              0.0s
 => [internal] settings cache mount permissions                                                                                                                                                                                0.0s
 => CACHED [stage-0  2/17] RUN dnf install -y python3 zlib zlib-devel brotli brotli-devel make gcc-c++ gzip git sqlite-devel && dnf clean all                                                                                  0.0s
 => CACHED [stage-0  3/17] RUN npm i -g corepack                                                                                                                                                                               0.0s
 => CACHED [stage-0  4/17] RUN corepack enable && corepack prepare yarn@4.2.2                                                                                                                                                  0.0s
 => CACHED [stage-0  5/17] RUN python3 -m venv /opt/venv                                                                                                                                                                       0.0s
 => CACHED [stage-0  6/17] RUN pip3 install mkdocs-techdocs-core==1.1.7                                                                                                                                                        0.0s
 => CACHED [stage-0  7/17] WORKDIR /app                                                                                                                                                                                        0.0s
 => CACHED [stage-0  8/17] RUN chown 1001:0 /app                                                                                                                                                                               0.0s
 => CACHED [stage-0  9/17] COPY --chown=1001:0 .yarn ./.yarn                                                                                                                                                                   0.0s
 => CACHED [stage-0 10/17] COPY --chown=1001:0 .yarnrc.yml ./                                                                                                                                                                  0.0s
 => CACHED [stage-0 11/17] COPY --chown=1001:0 yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./                                                                                                                 0.0s
 => CACHED [stage-0 12/17] RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz                                                                                                                                                   0.0s
 => CACHED [stage-0 13/17] RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,sharing=locked,uid=1001,gid=0     --mount=type=cache,target=/home/node/.yarn/berry/index,sharing=locked,uid=1001,gid=0     yarn workspa  0.0s
 => CACHED [stage-0 14/17] COPY --chown=1001:0 packages/backend/dist/bundle.tar.gz app-config*.yaml ./                                                                                                                         0.0s
 => CACHED [stage-0 15/17] RUN tar xzf bundle.tar.gz && rm bundle.tar.gz                                                                                                                                                       0.0s
 => CACHED [stage-0 16/17] RUN chown -R 1001:0 ./                                                                                                                                                                              0.0s
 => CACHED [stage-0 17/17] RUN fix-permissions ./                                                                                                                                                                              0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:9a2e7142e008023b5e218211ba72a516f51f0dda734dde9528599c75f76b1156                                                                                                                                   0.0s
 => => naming to docker.io/library/backstage                                                                                                                                                                                   0.0s
 => => naming to quay.io/ch007m/backstage-qshift-ocp:latest              
```
