### PR TITLE
Bump the docker login action from v1 to v3 to fix the warnings

### DIFF
--- a/.github/workflows/build-push-backstage-image.yml
+++ b/.github/workflows/build-push-backstage-image.yml
@@ -56,7 +56,7 @@ jobs:
           yarn build-ocp-image -t ${{ env.REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.BACKSTAGE_OCP_IMAGE_NAME }}:${{ env.SHA_SHORT }}
 
       - name: Login to Quay.io Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ROBOT_USER }}
@@ -110,7 +110,7 @@ jobs:
           yarn build-image -t ${{ env.REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.BACKSTAGE_IMAGE_NAME }}:${{ env.SHA_SHORT }}
 
       - name: Login to Quay.io Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ROBOT_USER }}


### PR DESCRIPTION
- Bump the docker login action from v1 to v3 to fix the warnings reported by github. 
- See: #138