### PR TITLE
Add NODE_OPTIONS=no-node-snapshot to avoid to get the UI error end of…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "18 || 20"
   },
   "scripts": {
-    "dev": "concurrently \"yarn start --config ../../app-config.local.yaml\" \"yarn start-backend --config ../../app-config.local.yaml\"",
+    "dev": "concurrently \"yarn start --config ../../app-config.local.yaml\" \"NODE_OPTIONS=--no-node-snapshot yarn start-backend --config ../../app-config.local.yaml\"",
     "start": "yarn workspace app start",
     "start-backend": "yarn workspace backend start",
     "build:backend": "yarn workspace backend build",


### PR DESCRIPTION
- Add `NODE_OPTIONS=--no-node-snapshot` to avoid to get the UI error end of the execution of a scaffolder template when we use node >= 20
- See #141