### PR TITLE
Fix template issues for f2f demo

### DIFF
--- a/locations/templates/quarkus-application/manifests/helm/deploy/templates/rolebinding.yaml
+++ b/locations/templates/quarkus-application/manifests/helm/deploy/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: edit
+  name: {{ include "quarkus-template.name" $ }}-edit
   namespace: "{{ .Values.app.namespace }}"
 subjects:
   - kind: ServiceAccount

--- a/locations/templates/quarkus-chatbot/manifests/helm/deploy/templates/rolebinding.yaml
+++ b/locations/templates/quarkus-chatbot/manifests/helm/deploy/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: edit
+  name: {{ include "quarkus-template.name" $ }}-edit
   namespace: "{{ .Values.app.namespace }}"
 subjects:
   - kind: ServiceAccount

--- a/locations/templates/quarkus-chatbot/template.yaml
+++ b/locations/templates/quarkus-chatbot/template.yaml
@@ -155,7 +155,6 @@ spec:
                 - io.quarkus:quarkus-rest-jackson
                 - io.quarkus:quarkus-smallrye-openapi
                 - io.quarkus:quarkus-smallrye-graphql
-                - io.quarkus:quarkus-hibernate-orm-rest-data-panache
 
         additionalProperties:
           title: Additional Properties
@@ -245,7 +244,7 @@ spec:
           healthEndpoint: ${{ parameters.healthEndpoint }}
           metricsEndpoint: ${{ parameters.metricsEndpoint }}
           additionalProperties: ${{ parameters.additionalProperties }}
-          starterCode: true
+          starterCode: false
 
     - id: saveApi
       name: Save the API
@@ -272,9 +271,6 @@ spec:
           java_package_name: ${{ parameters.java_package_name }}
           java_package_path: ${{ parameters.java_package_name | replace(".", "/") }}
           extensions: ${{ parameters.extensions }}
-          database: ${{ parameters.database }}
-          database_username: postgres
-          database_name: ${{ parameters.component_id}}-db
 
 
     - id: mavenDependenciesAdd

--- a/locations/templates/quarkus-rest-client/manifests/helm/deploy/templates/rolebinding.yaml
+++ b/locations/templates/quarkus-rest-client/manifests/helm/deploy/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: edit
+  name: {{ include "quarkus-template.name" $ }}-edit
   namespace: "{{ .Values.app.namespace }}"
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
- Fix template issues for f2f demo
- Make the RoleBinding name unique to avoid ArgoCD warning message
- Disable the option to generate code using `starterCode=false`
- Remove the non needed parameters for the DB
- Remove the Hibernate ORM extension
- Issue: #111 