### PR TITLE
Bump quarkus version from 3.11 to 3.12 which is now the new default. …

### DIFF
--- a/.github/test-data/quarkus-app-3.12-db.json
+++ b/.github/test-data/quarkus-app-3.12-db.json
@@ -4,7 +4,7 @@
     "component_id": "my-quarkus-app-job",
     "owner": "user:guest",
     "native": false,
-    "quarkusVersion": "io.quarkus.platform:3.11",
+    "quarkusVersion": "io.quarkus.platform:3.12",
     "groupId": "io.quarkus",
     "artifactId": "my-quarkus-app-job",
     "version": "1.0.0-SNAPSHOT",

--- a/.github/workflows/e2e-backstage.yml
+++ b/.github/workflows/e2e-backstage.yml
@@ -339,7 +339,7 @@ jobs:
            -X POST \
            -H 'Content-Type: application/json' \
            -H "Authorization: Bearer $BACKSTAGE_AUTH_SECRET" \
-           -d @${DATA_TEST_PATH}/quarkus-app-3.11-db.json)
+           -d @${DATA_TEST_PATH}/quarkus-app-3.12-db.json)
           
           echo $RESPONSE
 


### PR DESCRIPTION
- Bump quarkus version from 3.11 to 3.12 which is now the new default. This change is needed otherwise we will get an HTTP Error 400 from code.quarkus.io as 3.11 don't exist anymore. See screenshot from ticket
- #167