### PR TITLE
Rename QUAY_ROBOT_USER to QUAY_USERNAME

### DIFF
--- a/.github/workflows/build-push-backstage-image.yml
+++ b/.github/workflows/build-push-backstage-image.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: quay.io
-  REGISTRY_ORG: ${{ secrets.QUAY_ORG }}
+  REGISTRY_ORG: qshift
   BACKSTAGE_OCP_IMAGE_NAME: backstage-qshift-ocp
   BACKSTAGE_IMAGE_NAME: backstage-qshift
 
@@ -59,7 +59,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_ROBOT_USER }}
+          username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
       - name: Push the built image
@@ -113,7 +113,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_ROBOT_USER }}
+          username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
       - name: Push the built image

--- a/manifest/templates/argocd.tmpl
+++ b/manifest/templates/argocd.tmpl
@@ -28,7 +28,7 @@ spec:
           backstage:
             image:
               registry: "quay.io"
-              repository: "ch007m/backstage-qshift-ocp"
+              repository: "qshift/backstage-qshift-ocp"
               tag: "latest"
               pullPolicy: "Always"
             extraAppConfig:


### PR DESCRIPTION
- Rename action secret from QUAY_ROBOT_USER to QUAY_USERNAME to fix the issue of the job
- Replace ch007m quay org with qshift for the container image of backstage (kube or ocp)
- See #169