### PR TITLE
Add the missing namespace for the task quarkus-native

### DIFF
--- a/locations/templates/quarkus-application/manifests/helm/build-test-push/templates/00-task-quarkus-mandrel.yaml
+++ b/locations/templates/quarkus-application/manifests/helm/build-test-push/templates/00-task-quarkus-mandrel.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: quarkus-native-build
+  namespace: {{ .Values.app.namespace }}
 spec:
   workspaces:
     - name: project-dir


### PR DESCRIPTION
Add the missing namespace for the task quarkus-native packaged as helm chart