### PR TITLE
Bump Quarkus recommended version from 3.12.1 to 3.15.1

### DIFF
--- a/.github/test-data/quarkus-app-3.15-db.json
+++ b/.github/test-data/quarkus-app-3.15-db.json
@@ -4,7 +4,7 @@
     "component_id": "my-quarkus-app-job",
     "owner": "user:guest",
     "native": false,
-    "quarkusVersion": "3.12.1",
+    "quarkusVersion": "3.15.1",
     "groupId": "io.quarkus",
     "artifactId": "my-quarkus-app-job",
     "version": "1.0.0-SNAPSHOT",

--- a/.github/workflows/e2e-backstage.yml
+++ b/.github/workflows/e2e-backstage.yml
@@ -341,7 +341,7 @@ jobs:
            -X POST \
            -H 'Content-Type: application/json' \
            -H "Authorization: Bearer $BACKSTAGE_AUTH_SECRET" \
-           -d @${DATA_TEST_PATH}/quarkus-app-3.12-db.json)
+           -d @${DATA_TEST_PATH}/quarkus-app-3.15-db.json)
           
           echo $RESPONSE
 


### PR DESCRIPTION
- Bump Quarkus recommended version from 3.12.1 to 3.15.1 as 3.12 is not available anymore on code.quarkus.io
- Fix 2e2 job failing as during the job execution, the curl request to generate the quarkus project was failing due to wrong version requested